### PR TITLE
Fix code scanning alert no. 4: Overly permissive regular expression range

### DIFF
--- a/frontend/src/features/users/NewUserForm.jsx
+++ b/frontend/src/features/users/NewUserForm.jsx
@@ -6,8 +6,8 @@ import { faSave } from "@fortawesome/free-solid-svg-icons"
 import { ROLES } from "../../config/roles"
 import useTitle from "../../hooks/useTitle"
 
-const USER_REGEX = /^[A-z]{3,20}$/
-const PWD_REGEX = /^[A-z0-9!@#$%]{4,12}$/
+const USER_REGEX = /^[A-Za-z]{3,20}$/
+const PWD_REGEX = /^[A-Za-z0-9!@#$%]{4,12}$/
 
 const NewUserForm = () => {
     useTitle("techNotes: New User")


### PR DESCRIPTION
Fixes [https://github.com/0s1n/mernStack/security/code-scanning/4](https://github.com/0s1n/mernStack/security/code-scanning/4)

To fix the problem, we need to adjust the regular expression to correctly match only alphabetic characters. The correct ranges for alphabetic characters are `A-Z` for uppercase and `a-z` for lowercase. Therefore, the regex should be updated to use these ranges explicitly.

- Update the `USER_REGEX` on line 9 to use the correct ranges `A-Z` and `a-z`.
- Ensure that the functionality remains the same, i.e., the regex should still match usernames consisting of 3 to 20 alphabetic characters.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
