### PR TITLE
Fix code scanning alert no. 22: Database query built from user-controlled sources

### DIFF
--- a/backend/controllers/notesController.js
+++ b/backend/controllers/notesController.js
@@ -72,7 +72,7 @@ const updateNote = async (req, res) => {
     }
 
     // Check for duplicate title
-    const duplicate = await Note.findOne({ title }).collation({ locale: "en", strength: 2 }).lean().exec()
+    const duplicate = await Note.findOne({ title: { $eq: title } }).collation({ locale: "en", strength: 2 }).lean().exec()
 
     // Allow renaming of the original note 
     if (duplicate && duplicate?._id.toString() !== id) {


### PR DESCRIPTION
Fixes [https://github.com/0s1n/mernStack/security/code-scanning/22](https://github.com/0s1n/mernStack/security/code-scanning/22)

To fix the problem, we need to ensure that the user-provided `title` is treated as a literal value in the MongoDB query. This can be achieved by using the `$eq` operator, which ensures that the value is interpreted as a literal and not as a query object. Additionally, we should validate the `title` to ensure it is a string before using it in the query.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
