### PR TITLE
Fix code scanning alert no. 19: Database query built from user-controlled sources

### DIFF
--- a/backend/controllers/notesController.js
+++ b/backend/controllers/notesController.js
@@ -36,7 +36,7 @@ const createNewNote = async (req, res) => {
     }
 
     // Check for duplicate title
-    const duplicate = await Note.findOne({ title }).collation({ locale: "en", strength: 2 }).lean().exec()
+    const duplicate = await Note.findOne({ title: { $eq: title } }).collation({ locale: "en", strength: 2 }).lean().exec()
 
     if (duplicate) {
         return res.status(409).json({ message: 'Duplicate note title' })


### PR DESCRIPTION
Fixes [https://github.com/0s1n/mernStack/security/code-scanning/19](https://github.com/0s1n/mernStack/security/code-scanning/19)

To fix the problem, we need to ensure that the user-provided `title` is safely embedded into the MongoDB query. This can be achieved by using the `$eq` operator to ensure that the `title` is treated as a literal value. This approach prevents any potential NoSQL injection attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
