### PR TITLE
Fix code scanning alert no. 20: Database query built from user-controlled sources

### DIFF
--- a/backend/controllers/usersController.js
+++ b/backend/controllers/usersController.js
@@ -27,7 +27,7 @@ const createNewUser = async (req, res) => {
     }
 
     // Check for duplicate
-    const duplicate = await User.findOne({ username }).collation({ locale: "en", strength: 2 }).lean().exec()
+    const duplicate = await User.findOne({ username: { $eq: username } }).collation({ locale: "en", strength: 2 }).lean().exec()
 
     if (duplicate) {
         return res.status(409).json({ message: "Duplicate username" })
@@ -69,7 +69,7 @@ const updateUser = async (req, res) => {
     }
 
     // Check for duplicate
-    const duplicate = await User.findOne({ username }).collation({ locale: "en", strength: 2 }).lean().exec()
+    const duplicate = await User.findOne({ username: { $eq: username } }).collation({ locale: "en", strength: 2 }).lean().exec()
     // Allow updates to the original user
     if (duplicate && duplicate?._id.toString() !== id) {
         return res.status(409).json({ message: "Duplicate username" })


### PR DESCRIPTION
Fixes [https://github.com/0s1n/mernStack/security/code-scanning/20](https://github.com/0s1n/mernStack/security/code-scanning/20)

To fix the problem, we need to ensure that the `username` is treated as a literal value in the query. This can be achieved by using MongoDB's `$eq` operator, which ensures that the user input is interpreted as a literal value and not as a query object. This change should be made in the `createNewUser` and `updateUser` functions where the `username` is used in a query.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
