### PR TITLE
Fix code scanning alert no. 21: Database query built from user-controlled sources

### DIFF
--- a/backend/controllers/notesController.js
+++ b/backend/controllers/notesController.js
@@ -65,7 +65,7 @@ const updateNote = async (req, res) => {
     }
 
     // Confirm note exists to update
-    const note = await Note.findById(id).exec()
+    const note = await Note.findOne({ _id: { $eq: id } }).exec()
 
     if (!note) {
         return res.status(400).json({ message: 'Note not found' })


### PR DESCRIPTION
Fixes [https://github.com/0s1n/mernStack/security/code-scanning/21](https://github.com/0s1n/mernStack/security/code-scanning/21)

To fix the problem, we need to ensure that the `id` parameter is treated as a literal value in the MongoDB query. This can be achieved by using the `$eq` operator, which ensures that the user input is interpreted as a literal value and not as a query object. This change will prevent any potential NoSQL injection attacks.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
