### PR TITLE
Fix code scanning alert no. 23: Database query built from user-controlled sources

### DIFF
--- a/backend/controllers/usersController.js
+++ b/backend/controllers/usersController.js
@@ -62,7 +62,10 @@ const updateUser = async (req, res) => {
         return res.status(400).json({ message: "All fields are required" })
     }
 
-    const user = await User.findById(id).exec()
+    if (typeof id !== "string") {
+        return res.status(400).json({ message: "Invalid User ID" })
+    }
+    const user = await User.findOne({ _id: { $eq: id } }).exec()
 
     if (!user) {
         return res.status(400).json({ message: "User not found" })


### PR DESCRIPTION
Fixes [https://github.com/0s1n/mernStack/security/code-scanning/23](https://github.com/0s1n/mernStack/security/code-scanning/23)

To fix the problem, we need to ensure that the `id` parameter is validated to be a string and not a query object before it is used in the MongoDB query. This can be done by checking the type of `id` and ensuring it is a valid string. Additionally, we can use the `$eq` operator to ensure that the user input is interpreted as a literal value.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
